### PR TITLE
Use TIMESTAMP instead of TIMESTAMPTZ

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func insertData(db *sqlx.DB) {
 	now := time.Now()
 	fmt.Println("Inserting data with now()")
 	db.MustExec("INSERT INTO test (name) VALUES ('from default now()')")
-	db.MustExec("INSERT INTO test (name, ts) VALUES ('from now()', now())")
+	db.MustExec("INSERT INTO test (name, ts) VALUES ('from now()', now() AT TIME ZONE 'UTC')")
 	fmt.Printf("Inserting data with %v\n", now)
-	db.MustExec("INSERT INTO test (name, ts) VALUES ('from golang time.Now()', $1);", now)
+	db.MustExec("INSERT INTO test (name, ts) VALUES ('from golang time.Now()', $1);", now.UTC())
 }

--- a/schema.sql
+++ b/schema.sql
@@ -1,7 +1,7 @@
 CREATE TABLE test(
     n    SERIAL,
     name TEXT,
-    ts   TIMESTAMPTZ DEFAULT now()
+    ts   TIMESTAMP DEFAULT (now() AT TIME ZONE 'UTC')
 );
 
 ALTER DATABASE postgres SET timezone TO 'Etc/GMT+4'


### PR DESCRIPTION
Add explicit timestamp conversions to support `TIMESTAMP` column.

Do not merge, this is a demonstrational PR.